### PR TITLE
BF: catch issue where nan in adjmatrix can lead to bad lookup table, and...

### DIFF
--- a/brainx/tests/test_util.py
+++ b/brainx/tests/test_util.py
@@ -50,6 +50,10 @@ def test_make_cost_thresh_lookup():
     # costs in ascending order
     ## last vector is same as second vector rounded to 2 decimals
     npt.assert_almost_equal(lookup.actual_cost, lookup.cost, decimal=2)
+    # add nan to adj_mat to raise error
+    adj_mat[2,:] = np.nan
+    npt.assert_raises(ValueError, util.make_cost_thresh_lookup, adj_mat)
+
 
 def test_cost_size():
     n_nodes = 5

--- a/brainx/util.py
+++ b/brainx/util.py
@@ -192,7 +192,11 @@ def make_cost_thresh_lookup(adjacency_matrix):
        0.70
 
     """
-
+    ## check for nan in matrix, sorting will behave badly if nan found
+    if np.any(np.isnan(adjacency_matrix)):
+        raise ValueError('NAN found in adjacency matrix, this will cause'\
+                'improper behavior in sorting and improper results, '\
+                'please remove all nan ')
     ind = np.triu_indices_from(adjacency_matrix, k = 1)
     edges = adjacency_matrix[ind]
     nedges = edges.shape[0]


### PR DESCRIPTION
NANs were causing the sort function in make_cost_thresh_lookup to return meaningless lookup tables for thresholding the matrix...(and not raising an error)

added a catch to raise a ValueError warning user, and added a test to check for this
