### PR TITLE
added pip install jsonschema to travis_setup.sh

### DIFF
--- a/tools/travis_setup.sh
+++ b/tools/travis_setup.sh
@@ -6,5 +6,5 @@ WHEELHOUSE="--no-index --find-links=http://wheels.scikit-image.org/"
 pip install wheel nose coveralls
 pip install -r requirements.txt $WHEELHOUSE
 sudo apt-get install libzmq3-dev
-pip install ipython runipy
+pip install ipython runipy jsonschema
 


### PR DESCRIPTION
Attempt to fix Travis-CI build failure.  IPython notebook format now depends on the jsonschema package.